### PR TITLE
fix .env.example  bug

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 ############### Sensitive config ###############
 
 # private key for sending out app-specific transactions
-PRIV_KEY=""
+PRIVATE_KEY=""
 
 ############### General config ###############
 


### PR DESCRIPTION
use PRIV_KEY does not start correctly. Should be changed to PRIVATE_KEY